### PR TITLE
option to show used node prompt

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -136,7 +136,7 @@ CreateThread(function()
 				GroupName = CreateVarString(10, "LITERAL_STRING", GroupName)
 				PromptSetActiveGroupThisFrame(Group, GroupName)
 				PromptSetEnabled(Prompt, false)
-				PromptSetVisible(Prompt, true)
+				PromptSetVisible(Prompt, Config.ShowUsedNodePrompt)
 
 				print("test")
 			end
@@ -194,7 +194,7 @@ CreateThread(function()
 						GroupName = CreateVarString(10, "LITERAL_STRING", GroupName)
 						PromptSetActiveGroupThisFrame(Group, GroupName)
 						PromptSetEnabled(Prompt, false)
-						PromptSetVisible(Prompt, true)
+						PromptSetVisible(Prompt, Config.ShowUsedNodePrompt)
 					end
 				end
 			end

--- a/config.lua
+++ b/config.lua
@@ -4,6 +4,8 @@ Config.MinimumDistance = 2.0 -- Minimum distance required to enable prompts for 
 
 Config.Timeout = 2           -- Timeout (in minutes)
 
+Config.ShowUsedNodePrompt = true    -- Show greyed out prompt on used nodes
+
 -- Pre-spawned plants to check for. Leave blank to not have any prompts spawn on world objects.
 Config.Plants = {
     {                                               -- Follow this format exactly when adding in new world plants


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Herb prompts can block other actions, such as skinning immovable animals (e.g. buffalo). 

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
This option allows those that configure the script to hide the prompt, so users can clear an area to skin an animal or other action.

### Explain the necessity of these changes and how they will impact the framework or its users.
If the prompt is not cleared, other actions can be blocked by the prompt

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x ] Tested with latest vorp scripts
- [x ] Tested with latest artifacts

## Notes if any
This is a simple fix to give server owners the option to hide a prompt on used nodes.  