### PR TITLE
fixes VORPCORE/vorp_herbs#4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A plant picking and spawning system for RedM/Vorp.
 
 It will spawn plants configured places, and allow players to walk up to them and pick them for inventory items.
 A cooldown for each spot will be initiated afterward - this can be either configured per node, or on a global level (or both)!
-During cooldown the pick prompt will still be visible, but greyed out and unuseable.
+During cooldown you can choose if the prompt is still be visible but greyed out and unuseable, or not visible at all via the config.
 
 Pretty straightforward. Config is documented for your ease.
 

--- a/client/client.lua
+++ b/client/client.lua
@@ -15,6 +15,18 @@ local function contains(table, element)
 	return false
 end
 
+local function roundCoords(coords, decimal)
+	local multiplier = 10 ^ decimal
+	local x = math.floor(coords.x * multiplier + 0.5) / multiplier
+	local y = math.floor(coords.y * multiplier + 0.5) / multiplier
+	local z = math.floor(coords.z * multiplier + 0.5) / multiplier
+	return vec3(x, y, z)
+end
+
+local function isUsedNode(coords)
+	return contains(usedPoints, roundCoords(coords, 2))
+end
+
 local function GetArrayKey(array, value)
     for k,v in pairs(array) do
         if v == value then
@@ -42,7 +54,7 @@ end
 
 local function PlayerPick(destination)
 	if destination then
-		table.insert(usedPoints, destination.coords)
+		table.insert(usedPoints, roundCoords(destination.coords, 2))
 		local ped = PlayerPedId()
 		TaskTurnPedToFaceCoord(ped, destination.coords, -1)
 		Wait(2000)
@@ -77,7 +89,7 @@ local function PlayerPick(destination)
 end
 
 local function CreatePlant(destination)
-	if not DoesEntityExist(destination.plant) and not contains(usedPoints, destination.coords) then
+	if not DoesEntityExist(destination.plant) and not isUsedNode(destination.coords) then
 		local plantModel = joaat(destination.plantModel)
 		RequestModel(plantModel)
 		while not HasModelLoaded(plantModel) do
@@ -112,7 +124,7 @@ CreateThread(function()
 					end
 				end
 			end
-			while GetDistanceBetweenCoords(pedCoords, v.coords) <= Config.MinimumDistance and not isPicking and not contains(usedPoints, v.coords) do
+			while GetDistanceBetweenCoords(pedCoords, v.coords) <= Config.MinimumDistance and not isPicking and not isUsedNode(v.coords) do
 				Wait(1)
 				pedCoords = GetEntityCoords(ped)
 				GroupName = Config.Language.PromptGroupName .. " - " .. v.name
@@ -129,7 +141,7 @@ CreateThread(function()
 				print("test")
 			end
 
-			while GetDistanceBetweenCoords(pedCoords, v.coords) <= Config.MinimumDistance and not isPicking and contains(usedPoints, v.coords) do
+			while GetDistanceBetweenCoords(pedCoords, v.coords) <= Config.MinimumDistance and not isPicking and isUsedNode(v.coords) do
 				Wait(1)
 				pedCoords = GetEntityCoords(ped)
 				GroupName = Config.Language.PromptGroupName .. " - " .. v.name
@@ -158,7 +170,7 @@ CreateThread(function()
 				local model_hash = GetEntityModel(entity)
 				for k, v in ipairs(Config.Plants) do
 					local pedCoords = GetEntityCoords(PlayerPedId())
-					while Config.Plants[k].hash == model_hash and not contains(usedPoints, coords) and GetDistanceBetweenCoords(pedCoords, coords) < Config.MinimumDistance do
+					while Config.Plants[k].hash == model_hash and not isUsedNode(coords) and GetDistanceBetweenCoords(pedCoords, coords) < Config.MinimumDistance do
 						Wait(1)
 						pedCoords = GetEntityCoords(PlayerPedId())
 						GroupName = Config.Language.PromptGroupName .. " - " .. Config.Plants[k].name
@@ -187,7 +199,7 @@ CreateThread(function()
 							PlayerPick(fakeDestination)
 						end
 					end
-					while Config.Plants[k].hash == model_hash and contains(usedPoints, coords) and GetDistanceBetweenCoords(pedCoords, coords) < Config.MinimumDistance do
+					while Config.Plants[k].hash == model_hash and isUsedNode(coords) and GetDistanceBetweenCoords(pedCoords, coords) < Config.MinimumDistance do
 						Wait(1)
 						pedCoords = GetEntityCoords(PlayerPedId())
 						GroupName = Config.Language.PromptGroupName .. " - " .. Config.Plants[k].name


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request

As explained in issue https://github.com/VORPCORE/vorp_herbs/issues/4, herbs configured to use large bushes (such as the default config for oregano) would not properly go on cooldown and could be harvested indefinitely. 

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.

Prevent players from harvesting a resource significantly faster than the script was configured for. 

### Explain the necessity of these changes and how they will impact the framework or its users.

This change rounds the coordinates saved in the  `usedPoints` table to 2 decimal places to account for the small changes in the z coordinate returned by `GetEntityCoords()` depending on how the player approaches the entity.  Rounding to 2 decimal places seems to work both for keeping the used node on cooldown while not affecting other nearby herb nodes. 

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. 

Picked several nodes of small and large bushes, nearby and spread out.  
- Verified all nodes went on cooldown.  
- Verified all nodes could be harvested after the cooldown expired. 
- Resource Monitor showed 0.12% when no prompt was visible, ~4-5% when prompt to pick is displayed. 

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
Also included a small change to [README.md](https://github.com/VORPCORE/vorp_herbs/blob/main/README.md) to document the change from pull request https://github.com/VORPCORE/vorp_herbs/pull/3
