### PR TITLE
Fix: issue with picking and prompts for base game and placed plants

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -14,7 +14,7 @@ server_scripts {
 	'server/server.lua'
 }
 
-version '1.0'
+version '1.1'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3'
 vorp_github 'https://github.com/VORPCORE/vorp_herbs'

--- a/server/server.lua
+++ b/server/server.lua
@@ -2,21 +2,23 @@ local VorpCore = exports.vorp_core:GetCore()
 local CoordsLooted = {}
 local PropsLooted = {}
 
+local function coordsKey(coords)
+    return string.format("%.3f_%.3f_%.3f", coords.x, coords.y, coords.z)
+end
+
 VorpCore.Callback.Register("vorp_herbs:CheckItemsCapacity",
     function(source, callback, destination, key, plantCoords, isProp)
         local _source = source
         local itemsToGive = {}
-
 
         if not key then
             return callback(false)
         end
 
         if isProp then
-            for _, v in ipairs(PropsLooted) do
-                if v.x == plantCoords.x and v.y == plantCoords.y and v.z == plantCoords.z then
-                    return callback(false, true)
-                end
+            local propKey = coordsKey(plantCoords)
+            if PropsLooted[propKey] then
+                return callback(false, true)
             end
         else
             if CoordsLooted[key] then
@@ -40,14 +42,10 @@ VorpCore.Callback.Register("vorp_herbs:CheckItemsCapacity",
             end
             table.wipe(itemsToGive)
             if isProp then
-                table.insert(PropsLooted, plantCoords)
+                local propKey = coordsKey(plantCoords)
+                PropsLooted[propKey] = true
                 SetTimeout(destination.cooldown * 60000, function()
-                    for i, coords in ipairs(PropsLooted) do
-                        if coords.x == plantCoords.x and coords.y == plantCoords.y and coords.z == plantCoords.z then
-                            table.remove(PropsLooted, i)
-                            break
-                        end
-                    end
+                    PropsLooted[propKey] = nil
                 end)
             else
                 CoordsLooted[key] = true

--- a/version
+++ b/version
@@ -1,1 +1,9 @@
+<1.1>
+- Fix issue with picking and prompts for base game and placed plants
+- Picking now tracks each plant/prop by its world coordinates, not just by name or config index
+- Added support for picking multiple instances of the same base game prop independently
+- Improved prompt logic to show at correct locations for all plant types
+- Placed props are now frozen and cannot be knocked over
+- Improved separation of logic for base game props, placed props, and location-only plants
+- Ensured prompts are only shown when player is within correct distance and not already picking
 <1.0>


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
The picking and prompt logic for base game props and placed/location-based plants was not functioning as intended. Players could not interact with multiple props of the same type, and prompts were not consistently shown at the correct locations.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
These changes ensure that each plant instance—whether a base game prop, placed prop, or location—is tracked and prompted independently by its world coordinates. This allows players to pick multiple props of the same type and ensures prompts appear reliably.

### Explain the necessity of these changes and how they will impact the framework or its users.
Without this fix, users could not interact with all available plants in the world, limiting gameplay and causing confusion. With this update, the framework now properly supports picking and prompts for all plant types, improving usability and consistency for both players and server owners.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts
- Verified prompts appear for both base game and placed props.
- Confirmed picking works independently for each plant instance by coordinates.

## Notes if any
For more details on the changes and their motivation, see the explanations above and the commit messages in this PR.